### PR TITLE
Handle null string in controls-view.js truncateSutitle function

### DIFF
--- a/src/common/js/controls-view.js
+++ b/src/common/js/controls-view.js
@@ -229,7 +229,7 @@
          * @description truncate subtitle with elipsis
          */
         this.truncateSubtitle = function(string) {
-           if (string.length > 150) {
+           if (string && string.length > 150) {
               return string.substring(0,147)+'...';
            } else {
               return string;


### PR DESCRIPTION
Subtitle string can be null, which causes an exception in truncateSubtitle function.