### PR TITLE
add engiens prop to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Web App Starter Kit for Fire TV",
   "license": "CC0-1.0",
   "repository": "https://github.com/amzn/web-app-starter-kit-for-fire-tv",
+  "engines": {
+    "node": ">= ??"
+  },
   "files": [
     "src/**/*",
     "docs/**/*",


### PR DESCRIPTION
It is currently unclear here, or anywhere I can find in Firestick TV docs what version(s) of Node are supported by Firestick TV. It would be great to have this available so users can understand what es2015 features are available and whether or not they need to transpile applications to work with firestick tv.