### PR TITLE
Fixed formatting of headers in some markdown documents.

### DIFF
--- a/docs/brightcove-support.md
+++ b/docs/brightcove-support.md
@@ -1,4 +1,3 @@
-##Brightcove
+## Brightcove
 ---------------------------
 To create an app based on Brightcove content, see [this documentation](/brightcove.md)
-

--- a/docs/kaltura-support.md
+++ b/docs/kaltura-support.md
@@ -1,5 +1,3 @@
-##Kaltura
+## Kaltura
 ---------------------------
 To create an app based on Kaltura content, see [Kaltura's fork of the Web App Starter Kit for Fire TV](https://github.com/kaltura/web-app-starter-kit-for-fire-tv).
-
-

--- a/docs/mrss-support.md
+++ b/docs/mrss-support.md
@@ -1,8 +1,8 @@
-##MRSS
+## MRSS
 ---------------------------
 The Web App Starter Kit has an mrss project which supports MRSS feeds.
 
-###Setting the MRSS Feed URL
+### Setting the MRSS Feed URL
 To point the app to your content feed, you must edit the `init.js` in your project directory. The file contains a very simple object for application settings. Set the `dataURL` parameter to point to your MRSS feed URL.
 
     //initialize the app
@@ -15,7 +15,7 @@ To point the app to your content feed, you must edit the `init.js` in your proje
         displayButtons:false
     };
 
-###Editing the model-mrss
+### Editing the model-mrss
 There may be data transformation needed to get your content working in the application, these changes will need to be made in the model-mrss.js file that is located in the /src/common/js/directory.
 In the model-mrss file you will find a method called `handleXMLData`, which is where you will make your adjustments. Note that this function casts the object as a jQuery object, this is so that we can take advantage of jQuery methods to easily traverse the XML DOM.
 In the below example you will see the data object that the application expects, to map your data, change any of the DOM references needed.

--- a/docs/ooyala-support.md
+++ b/docs/ooyala-support.md
@@ -1,3 +1,3 @@
-##Ooyala
+## Ooyala
 ---------------------------
 To create an app based on Ooyala content, see [Ooyala's fork of the Web App Starter Kit for Fire TV](https://github.com/ooyala/web-app-starter-kit-for-fire-tv).

--- a/docs/youtube-support.md
+++ b/docs/youtube-support.md
@@ -1,16 +1,16 @@
-##YouTube
+## YouTube
 ---------------------------
 The Web App Starter Kit currently supports making a Web App based on YouTube content through the provided [YouTube Developer API's](https://developers.google.com/youtube/getting_started).
 
-There is a working YouTube example in the `src/projects/youtube` directory. ***NOTE:** You will need to add your YouTube Developer Key for the example to work (see below).*
+There is a working YouTube example in the `src/projects/youtube` directory. * **NOTE:** You will need to add your YouTube Developer Key for the example to work (see below).*
 
 Here are the steps to getting a YouTube based application up and running:
 
-###Acquire a YouTube Developer Key
+### Acquire a YouTube Developer Key
 
 To utilize the YouTube functionality of the starter kit you must acquire a valid YouTube Developer key. This is a string hash which uniquely identifies your application to YouTube. All you need to acquire this key is a valid Google account. To obtain the key please view the video on the [Getting Started Guide from Google](https://developers.google.com/youtube/v3/getting-started#before-you-start).
 
-###Customizing the YouTube Project
+### Customizing the YouTube Project
 
 In the `init.js` file you will find a settings object similar to:
 


### PR DESCRIPTION
The following documents had some minor formatting errors:
 - docs/brightcove-support.md
 - docs/kaltura-support.md
 - docs/mrss-support.md
 - docs/ooyala-support.md
 - docs/youtube-support.md

For example:

Changed `##Brightcove` to `## Brightcove` to result in:
## Brightcove