### PR TITLE
multiPlaylists: sub sections for Youtube Playlists

### DIFF
--- a/src/common/js/model-youtube-api.js
+++ b/src/common/js/model-youtube-api.js
@@ -252,6 +252,14 @@
                     this.categoryData.push(this.premadeChannels[i].title);
                 }
             }
+            else if (this.premadeChannels[i].type === "multiPlaylists") {
+                this.channelData.push({
+                    type: "multiPlaylists",
+                    ids: this.premadeChannels[i].ids,
+                    title: "All Playlists"
+                });
+                this.categoryData.push(this.premadeChannels[i].title);
+            }
             dataLoadedCallback();
         }.bind(this);
 


### PR DESCRIPTION

This allows YouTube playlists to be added as a list.

Example Usage
```
        {
            type: "multiPlaylists",
            ids: ["PLhr1KZpdzukf6YADEpM6nFEZs7VDhEs5U",
                    "PLhr1KZpdzukeiCFgRccZ677GhHoP1OD8S",
                    "PLhr1KZpdzukeEDdaSY-HHJuX30WsoGhuW"
                ],
            title: "Many Playlists"
        },
```
Example output: http://crandellws.github.io/Unity-Focus/

closes amzn#31 for this more concise code change without formatting as per code of conduct...


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. Credit would be nice...
