### PR TITLE
Fix search bug with case and prevent errors in searching if title or description doesn't exist

### DIFF
--- a/src/common/js/model-json.js
+++ b/src/common/js/model-json.js
@@ -315,6 +315,7 @@
          */
          this.getDataFromSearch = function (searchTerm, searchCallback) {
             this.currData = [];
+            searchTerm = searchTerm.toLowerCase();
             for (var i = 0; i < this.mediaData.length; i++) {
                 if (this.mediaData[i].title.toLowerCase().indexOf(searchTerm) >= 0 || this.mediaData[i].description.toLowerCase().indexOf(searchTerm) >= 0) {
                     //make sure the date is in the correct format

--- a/src/common/js/model-json.js
+++ b/src/common/js/model-json.js
@@ -317,7 +317,13 @@
             this.currData = [];
             searchTerm = searchTerm.toLowerCase();
             for (var i = 0; i < this.mediaData.length; i++) {
-                if (this.mediaData[i].title.toLowerCase().indexOf(searchTerm) >= 0 || this.mediaData[i].description.toLowerCase().indexOf(searchTerm) >= 0) {
+                if (
+                    (this.mediaData && this.mediaData[i]) &&
+                    (
+                        (this.mediaData[i].title && this.mediaData[i].title.toLowerCase().indexOf(searchTerm) >= 0)||
+                        (this.mediaData[i].description && this.mediaData[i].description.toLowerCase().indexOf(searchTerm) >= 0)
+                    )
+                ) {
                     //make sure the date is in the correct format
                     if(this.mediaData[i].pubDate) {
                         this.mediaData[i].pubDate = exports.utils.formatDate(this.mediaData[i].pubDate);


### PR DESCRIPTION
No documented issue

- Made the searchTerm lowercase, since we are comparing it against a lowercase title and description
- Fix the search loop so that it doesn't break if the media item's title or description doesn't exist


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
