### PR TITLE
Fix a typo in viewport tag

### DIFF
--- a/out/simple-live/index.html
+++ b/out/simple-live/index.html
@@ -30,7 +30,7 @@
 
         var initialScale = Math.max(screen.width, screen.height)/1920;
 
-        vp.setAttribute('content','width=device-width, initial-scale=' + initialScale + ', maximum-scale=' + initialScale, + 'minimum-scale=' + initialScale);
+        vp.setAttribute('content','width=device-width, initial-scale=' + initialScale + ', maximum-scale=' + initialScale + ', minimum-scale=' + initialScale);
 
     </script>
     <link rel="stylesheet" type="text/css" href="firetv.css" inline>


### PR DESCRIPTION
The comma was misplaced, causing the minimal scale not to be set in the attribute.

*Description of changes:*
Placed the comma where it belongs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
